### PR TITLE
Implementação ws2812b_draw_b

### DIFF
--- a/inc/ws2812b.c
+++ b/inc/ws2812b.c
@@ -128,3 +128,16 @@ void prepare_glyph(uint8_t *glyph)
 {
     fliplr(glyph);
 }
+
+void ws2812b_draw_b(const uint8_t *glyph, const uint8_t color, const uint8_t intensity)
+{
+    uint8_t i;
+    uint32_t composite_value;
+    for(i = 0; i < 25; i++) {
+        if(glyph[24-i] == 1) {
+            composite_value = ws2812b_compose_led_value(color, intensity);
+            send_ws2812b_data(pio0, 0, composite_value);
+        }
+        else send_ws2812b_data(pio0, 0, 0);
+    }
+}

--- a/inc/ws2812b.h
+++ b/inc/ws2812b.h
@@ -72,6 +72,8 @@ ws2812b_t *init_ws2812b(PIO pio, uint8_t pin);
  */
 void ws2812b_draw(const ws2812b_t *ws, const uint8_t *glyph, const uint8_t color, const uint8_t intensity);
 
+void ws2812b_draw_b(const uint8_t *glyph, const uint8_t color, const uint8_t intensity);
+
 /**
  * @brief Desliga todos os LEDs da matriz WS2812B.
  * 


### PR DESCRIPTION
* Implementação da função ws2812b_draw_b que permite o envio de informações sem a necessidade de ws2812b_t